### PR TITLE
Support logging to stderr

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -57,7 +57,11 @@ func SetupLogging(cfg LogConfig) {
 		}
 		l.out = f
 	} else {
-		l.out = os.Stdout
+		if cfg.File == "stderr" {
+			l.out = os.Stderr
+		} else {
+			l.out = os.Stdout
+		}
 	}
 	l.level = get_level(cfg.Level)
 	l.ltype = cfg.Type


### PR DESCRIPTION
When using the "console" log type, you can
specify the "file" of "stderr", and print log
messages to STDERR instead of STDOUT
