### PR TITLE
ansi supports color tags split across lines. Also, better rainbows with whitespace

### DIFF
--- a/ansi/printf.go
+++ b/ansi/printf.go
@@ -38,7 +38,7 @@ var (
 		"W": "01;37", // white (BOLD)
 	}
 
-	re = regexp.MustCompile(`@[kKrRgGyYbBmMpPcCwW*]{.*?}`)
+	re = regexp.MustCompile(`(?s)@[kKrRgGyYbBmMpPcCwW*]{.*?}`)
 )
 
 var colorable = isatty.IsTerminal(os.Stdout.Fd())

--- a/ansi/printf.go
+++ b/ansi/printf.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"unicode"
 
 	"github.com/mattn/go-isatty"
 )
@@ -54,9 +55,15 @@ func colorize(s string) string {
 		}
 		if m[1:2] == "*" {
 			rainbow := "RYGCBM"
+			skipCount := 0
 			s := ""
 			for i, c := range m[3 : len(m)-1] {
-				j := i % len(rainbow)
+				if unicode.IsSpace(c) { //No color wasted on whitespace
+					skipCount++
+					s += string(c)
+					continue
+				}
+				j := (i - skipCount) % len(rainbow)
 				s += "\033[" + colors[rainbow[j:j+1]] + "m" + string(c) + "\033[00m"
 			}
 			return s

--- a/ansi/printf_test.go
+++ b/ansi/printf_test.go
@@ -45,6 +45,7 @@ func TestColorizer(t *testing.T) {
 		{"host error: %s", "host error: %s", "host error: %s"},
 		{"@r{multiline\nstring}", "\033[00;31mmultiline\nstring\033[00m", "multiline\nstring"},
 		{"@*{R\nA\nI\nN\nB\nO\nW}", "\033[01;31mR\033[00m\n\033[01;33mA\033[00m\n\033[01;32mI\033[00m\n\033[01;36mN\033[00m\n\033[01;34mB\033[00m\n\033[01;35mO\033[00m\n\033[01;31mW\033[00m", "R\nA\nI\nN\nB\nO\nW"},
+		{"@*{R\nA I\tN\vB\fO   W}", "\033[01;31mR\033[00m\n\033[01;33mA\033[00m \033[01;32mI\033[00m\t\033[01;36mN\033[00m\v\033[01;34mB\033[00m\f\033[01;35mO\033[00m   \033[01;31mW\033[00m", "R\nA I\tN\vB\fO   W"},
 	}
 
 	for _, test := range tests {

--- a/ansi/printf_test.go
+++ b/ansi/printf_test.go
@@ -6,9 +6,9 @@ import (
 
 func TestColorizer(t *testing.T) {
 	var tests = []struct {
-		In  string
-		Out string
-		Not string
+		In  string //The input to the test case
+		Out string //The expected output when colorization is on
+		Not string //The expected output when colorization is off
 	}{
 		{"@k{color}", "\033[00;30mcolor\033[00m", "color"},
 		{"@K{COLOR}", "\033[01;30mCOLOR\033[00m", "COLOR"},
@@ -43,6 +43,8 @@ func TestColorizer(t *testing.T) {
 
 		{"@s@d@l@f", "@s@d@l@f", "@s@d@l@f"},
 		{"host error: %s", "host error: %s", "host error: %s"},
+		{"@r{multiline\nstring}", "\033[00;31mmultiline\nstring\033[00m", "multiline\nstring"},
+		{"@*{R\nA\nI\nN\nB\nO\nW}", "\033[01;31mR\033[00m\n\033[01;33mA\033[00m\n\033[01;32mI\033[00m\n\033[01;36mN\033[00m\n\033[01;34mB\033[00m\n\033[01;35mO\033[00m\n\033[01;31mW\033[00m", "R\nA\nI\nN\nB\nO\nW"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #4 
Added the flag to make the `.` regexp operator match the newline character.

Also bundled in: rainbows don't waste colors on whitespace.