### PR TITLE
Updated canonical naming returned for better list support

### DIFF
--- a/tree/cursor.go
+++ b/tree/cursor.go
@@ -176,6 +176,7 @@ func (c *Cursor) Canonical(o interface{}) (*Cursor, error) {
 					}
 				}
 				o = o.([]interface{})[i]
+				canon.Push(fmt.Sprintf("%d", i))
 			} else {
 				// if k is a string, look for immediate map descendants who have
 				//     'name', 'key' or 'id' fields matching k
@@ -186,8 +187,8 @@ func (c *Cursor) Canonical(o interface{}) (*Cursor, error) {
 						Path: canon.Nodes,
 					}
 				}
+				canon.Push(fmt.Sprintf("%s", k))
 			}
-			canon.Push(fmt.Sprintf("%d", i))
 
 		case map[string]interface{}:
 			canon.Push(k)

--- a/tree/cursor_test.go
+++ b/tree/cursor_test.go
@@ -138,12 +138,12 @@ var _ = Describe("Cursors", func() {
 			Ω(canon).ShouldNot(BeNil())
 			Ω(canon.String()).Should(Equal("key.list.second.value"))
 		})
-		It("Uses named pathing when index requested", func() {
+		It("Uses indexed pathing when index requested", func() {
 			c, _ := tree.ParseCursor("key.list.1.value")
 			canon, err := c.Canonical(T)
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(canon).ShouldNot(BeNil())
-			Ω(canon.String()).Should(Equal("key.list.second.value"))
+			Ω(canon.String()).Should(Equal("key.list.1.value"))
 		})
 
 		It("handles maps all the way down", func() {


### PR DESCRIPTION
If lists have a name key, and it is used in the path, canonical
name should return the name in the canonical path. If the cursor
is requested via an index, use the index in the canonical path.