### PR TITLE
Allow Globs with '*' to not error when sub-items are not found

### DIFF
--- a/tree/cursor.go
+++ b/tree/cursor.go
@@ -249,7 +249,9 @@ func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
 				for i, v := range o.([]interface{}) {
 					sub, err := resolver(v, append(here, fmt.Sprintf("%d", i)), path, pos+1)
 					if err != nil {
-						return nil, err
+						if _, ok := err.(NotFoundError); !ok {
+							return nil, err
+						}
 					}
 					paths = append(paths, sub...)
 				}
@@ -258,7 +260,9 @@ func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
 				for k, v := range o.(map[string]interface{}) {
 					sub, err := resolver(v, append(here, k), path, pos+1)
 					if err != nil {
-						return nil, err
+						if _, ok := err.(NotFoundError); !ok {
+							return nil, err
+						}
 					}
 					paths = append(paths, sub...)
 				}
@@ -267,7 +271,9 @@ func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
 				for k, v := range o.(map[interface{}]interface{}) {
 					sub, err := resolver(v, append(here, fmt.Sprintf("%v", k)), path, pos+1)
 					if err != nil {
-						return nil, err
+						if _, ok := err.(NotFoundError); !ok {
+							return nil, err
+						}
 					}
 					paths = append(paths, sub...)
 				}

--- a/tree/cursor_test.go
+++ b/tree/cursor_test.go
@@ -391,6 +391,32 @@ var _ = Describe("Cursors", func() {
 				Ω(l[1].String()).Should(Equal("key.simple.list.1"))
 				Ω(l[2].String()).Should(Equal("key.simple.list.2"))
 			})
+
+			It("doesn't error when globbing with '*' doesn't find things", func() {
+				c, err := tree.ParseCursor("key.list.*.optional")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				l, err := c.Glob(T)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(len(l)).Should(Equal(1))
+				Expect(l[0].String()).Should(Equal("key.list.1.optional"))
+			})
+			It("throws an error when globbing without '*' doesn't find things", func() {
+				c, err := tree.ParseCursor("key.list.0.optional")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				l, err := c.Glob(T)
+				Expect(err).Should(HaveOccurred())
+				Expect(l).Should(BeNil())
+			})
+			It("throws an error when missing nodes are prior to the first '*' of a Glob", func() {
+				c, err := tree.ParseCursor("key.listnotfound.*.missing")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				l, err := c.Glob(T)
+				Expect(err).Should(HaveOccurred())
+				Expect(l).Should(BeNil())
+			})
 		}
 
 		Context("With JSON trees", func() {
@@ -407,7 +433,8 @@ var _ = Describe("Cursors", func() {
         "quantity": 2
       },{
         "name": "bananas",
-        "quantity": 7
+        "quantity": 7,
+        "optional": "present"
       },{
         "name": "grapes",
         "quantity": 22
@@ -445,6 +472,7 @@ key:
       quantity: 2
     - name:     bananas
       quantity: 7
+      optional: present
     - name:     grapes
       quantity: 22
   nums:


### PR DESCRIPTION
When using '*' in a glob, it should be permissable to not find things
underneath. Do not return errors for such cases. Do for when missing
items are not underneath the scope of a '*'.